### PR TITLE
Fixed table in specifications

### DIFF
--- a/docs/specification/reference.md
+++ b/docs/specification/reference.md
@@ -215,6 +215,7 @@ Example: The `rental_methods` field contains values `creditcard`, `paypass`, etc
   `language` | Yes | Language | IETF BCP 47 language code.  Must match one of the values specified by the `languages` field in `system_information.json`.
 
   Most commonly specified as `Array<Localized String>` when specifying translations in multiple languages.  See [Localization](#localization) for more details.
+  
 * Non-negative Float - A 32-bit floating point number greater than or equal to 0.
 * Non-negative Integer - An integer greater than or equal to 0.
 * Object - A JSON element consisting of key-value pairs (fields).


### PR DESCRIPTION
At https://gbfs.org/specification/reference/, in the Field Types section, the list doesn’t format correctly after Localized String (after the table with the example).

Before | After
-- | --
![image](https://github.com/MobilityData/gbfs.org/assets/2423604/eeccc61d-21da-4b53-9c13-b048421e10cf) | ![image](https://github.com/MobilityData/gbfs.org/assets/2423604/2f272f9a-2b28-4e7d-9d8b-bb6d31440003)