### PR TITLE
Release Candidate Feature Implementation

### DIFF
--- a/docs/specification/index.md
+++ b/docs/specification/index.md
@@ -23,7 +23,14 @@ when changes are made to the specification, the changes are placed into Release 
 * **The implementors MUST be stakeholders other than The Advocate (who opened the PR).**
 * **Once implemented successfully, the change is merged into an official current release.**
 
-**[See the Latest Reference of GBFS](reference)**
+To support this process and ensure it is as timely as possible, MobilityData tracks implementation through one-on-one discussions and other stakeholder events and by examining GBFS datasets. To improve this tracking process, GBFS data producers and consumers are encouraged to add their organization here if they have implemented or are planning on implementing any of these release candidate changes. After votes are called, MobilityData will update this list to reflect organizations that included an implementation note in their vote.
+### Implementation Status
+The following items have passed through the voting process and will be included in the next version.
+<iframe class="airtable-embed" src="https://airtable.com/embed/appQvTu1nOy6fJwUP/shrNl0TSZGrqD3REa?backgroundColor=red&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="633" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+<a class="button no-icon" href="https://airtable.com/appQvTu1nOy6fJwUP/shraqzpVkb2PlkMnq" target="_blank">Request a change</a>
+<a class="button no-icon" href="https://airtable.com/appQvTu1nOy6fJwUP/shrkMt5JTIiuPFlhY" target="_blank">Add your organization (producers)</a>
+<a class="button no-icon" href="https://airtable.com/appQvTu1nOy6fJwUP/shrNEkNZ2JBWYdMmw" target="_blank">Add your organization (consumers)</a>
 
 <hr>
 


### PR DESCRIPTION
This PR moves the Release Candidate Feature Implementation from the [Github wiki](https://github.com/MobilityData/gbfs/wiki/Release-Candidate-Feature-Implementation) to https://gbfs.org/specification/.

It follows the same implementation as the [GTFS adoption tracker](https://gtfs.org/extensions/fares-v2/#adoption-tracker).

Before | After
-- | --
<img width="1800" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/4a6f5e3b-9566-44fd-9efa-6dc29e5c25bb"> | <img width="1800" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/d236d97d-a672-45d0-a7d6-a1feae1c5548">