### PR TITLE
Remove roadmap from the navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # GBFS: A Common Language for Shared Mobility
 
 <div class="landing-page">
-    <a class="button" href="specification">Specification</a><a class="button" href="data-quality">Data Quality</a><a class="button" href="toolbox">Toolbox</a><a class="button" href="learn">Learn</a><a class="button" href="participate">Participate</a><a class="button" href="roadmap">Roadmap</a></div>
+    <a class="button" href="specification">Specification</a><a class="button" href="data-quality">Data Quality</a><a class="button" href="toolbox">Toolbox</a><a class="button" href="learn">Learn</a><a class="button" href="participate">Participate</a></div>
 
 GBFS provides a common language for shared mobility operators to share information about services available to travelers. GBFS includes information about vehicles (bicycles, scooters, moped, and cars), stations, pricing and more:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,0 @@
-# Roadmap
-## Get Involved
-This road map has been developed based on feedback we have received from the GBFS community and shared mobility industry. If there are features or changes that you think should be part of this roadmap we'd like to hear about them. GBFS is an open project and we value your input.
-If you would like to contribute to the project please use the **Submit idea** button or get in touch with us at [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org) to coordinate contribution.
-
-<iframe src="https://portal.productboard.com/vejjy7p1a6gzdqbs2ev2ztn6?hide_logo=1" frameborder="0" height=500px width=100%></iframe>
-<hr>
-<iframe src="https://portal.productboard.com/xcpvceqebovhprgzprgr2ryb?hide_logo=1" frameborder="0" height=500px width=100%></iframe>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,4 +111,3 @@ nav:
     - Data Policy Europe: learn/white-papers/data-policy-europe.md
   - FAQ: learn/faq.md
 - Participate: participate.md
-- Roadmap: roadmap.md


### PR DESCRIPTION
This PR removes the roadmap from the navigation on https://gbfs.org/ as this section is now displayed on the page https://gbfs.org/participate/#get-involved.

Before | After
-- | --
<img width="1800" alt="Screenshot 2023-11-17 at 09 16 24" src="https://github.com/MobilityData/gbfs.org/assets/2423604/a1e7bf3d-e83c-4ee3-96bf-0da94aad4dc9"> | <img width="1800" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/83d75d29-c163-4fc9-bdcb-a2758e16f5df">