### PR TITLE
Update repo URLs from NABSA to MobilityData

### DIFF
--- a/docs/learn/faq.md
+++ b/docs/learn/faq.md
@@ -80,15 +80,15 @@ GBFS does not contain operational data. GBFS only contains real-time data that i
 
 **Where can I find GBFS data?**
 
-A catalog of public GBFS data sources, know as [systems.csv](https://github.com/NABSA/gbfs/blob/master/systems.csv), is maintained on the GBFS GitHub repository. 
+A catalog of public GBFS data sources, know as [systems.csv](https://github.com/MobilityData/gbfs/blob/master/systems.csv), is maintained on the GBFS GitHub repository. 
 
 <br>**Why is systems.csv important?**
 
-The [systems.csv](https://github.com/NABSA/gbfs/blob/master/systems.csv) catalog is the primary index of GBFS data sources, it allows developers to build software on top of it, provides a source for research projects, and demonstrates the reach of the specification worldwide. 
+The [systems.csv](https://github.com/MobilityData/gbfs/blob/master/systems.csv) catalog is the primary index of GBFS data sources, it allows developers to build software on top of it, provides a source for research projects, and demonstrates the reach of the specification worldwide. 
 
 <br>**Who maintains systems.csv?**
 
-The [systems.csv](https://github.com/NABSA/gbfs/blob/master/systems.csv) catalog is currently maintained by MobilityData and the GBFS community. If you have or are aware of a system that does not appear on the list please add it by opening a pull request or notify MobilityData at: [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org).
+The [systems.csv](https://github.com/MobilityData/gbfs/blob/master/systems.csv) catalog is currently maintained by MobilityData and the GBFS community. If you have or are aware of a system that does not appear on the list please add it by opening a pull request or notify MobilityData at: [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org).
 
 <br>**Are all of the systems in systems.csv compliant with the specification?**
 
@@ -116,11 +116,11 @@ While GBFS, or the General Bikeshare Feed Specification, has its roots in bikesh
 
 **How is the specification updated?**
 
-GBFS is an open source project developed under a consensus-based governance model. Contributors come from across the shared mobility industry, public sector, civic technology and elsewhere. Proposals for changes or additions to the specification are made through Pull Requests. Once the community has had adequate time to comment and iterate on a proposal, the proposal is put to a vote. If the proposal passes, it becomes part of a release candidate. When the release candidate has been successfully implemented in a public data set, it becomes an official release. The complete governance and change process can be found [here](https://github.com/NABSA/gbfs#governance--overview-of-the-change-process).
+GBFS is an open source project developed under a consensus-based governance model. Contributors come from across the shared mobility industry, public sector, civic technology and elsewhere. Proposals for changes or additions to the specification are made through Pull Requests. Once the community has had adequate time to comment and iterate on a proposal, the proposal is put to a vote. If the proposal passes, it becomes part of a release candidate. When the release candidate has been successfully implemented in a public data set, it becomes an official release. The complete governance and change process can be found [here](https://github.com/MobilityData/gbfs/blob/master/governance.md).
 
 <br>**How can I propose a change to the specification?**
 
-If you are interested in proposing a modification, you can do so at the GBFS GitHub repo. If you do not have the solution to the problem and would like to start a discussion, we recommend you [open an issue](https://github.com/NABSA/gbfs/issues). If you have  a solution and would like to propose a change, please [open a Pull Request](https://github.com/NABSA/gbfs/pulls). 
+If you are interested in proposing a modification, you can do so at the GBFS GitHub repo. If you do not have the solution to the problem and would like to start a discussion, we recommend you [open an issue](https://github.com/MobilityData/gbfs/issues). If you have  a solution and would like to propose a change, please [open a Pull Request](https://github.com/MobilityData/gbfs/pulls). 
 
 <hr>
 
@@ -196,5 +196,5 @@ There are a number of ways you can get involved with our organization and the Sh
 
 - Learn more about us: [www.mobilitydata.org](https://www.mobilitydata.org)
 - Join our slack: [https://share.mobilitydata.org/slack](https://share.mobilitydata.org/slack)
-- Join us on Github: [github.com/NABSA/gbfs](https://github.com/NABSA/gbfs)
+- Join us on Github: [github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs)
 - Become a member: [bit.ly/Membership-form-2021](https://bit.ly/Membership-form-2021)

--- a/docs/learn/white-papers/data-policy-europe.md
+++ b/docs/learn/white-papers/data-policy-europe.md
@@ -43,7 +43,7 @@ Your tender should require a publicly accessible GBFS API and should set expecta
 
 >**_Data sharing requirements:_**
 >
->* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
+>* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
 >* _The GBFS API must be available to the public on the open internet without requiring authentication._
 
 ### Determine what data to require in a comprehensive policy.
@@ -153,7 +153,7 @@ At minimum, a shared mobility data policy should:
 
 **Sample policy language**
 
->_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
+>_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
 >
 >_[COMPANY] shall inform [PERMITTING AGENCY] of the URL for the gbfs.json endpoint prior to deploying vehicles. [COMPANY] must notify [PERMITTING AGENCY] at least 30 days prior to changing the URL of the gbfs.json endpoint._
 >

--- a/docs/learn/white-papers/data-policy-europe.md
+++ b/docs/learn/white-papers/data-policy-europe.md
@@ -43,7 +43,7 @@ Your tender should require a publicly accessible GBFS API and should set expecta
 
 >**_Data sharing requirements:_**
 >
->* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/NABSA/gbfs/](https://github.com/NABSA/gbfs/blob/master/gbfs.md)._
+>* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
 >* _The GBFS API must be available to the public on the open internet without requiring authentication._
 
 ### Determine what data to require in a comprehensive policy.
@@ -153,7 +153,7 @@ At minimum, a shared mobility data policy should:
 
 **Sample policy language**
 
->_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/NABSA/gbfs/](https://github.com/NABSA/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
+>_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
 >
 >_[COMPANY] shall inform [PERMITTING AGENCY] of the URL for the gbfs.json endpoint prior to deploying vehicles. [COMPANY] must notify [PERMITTING AGENCY] at least 30 days prior to changing the URL of the gbfs.json endpoint._
 >
@@ -176,7 +176,7 @@ At minimum, a shared mobility data policy should:
 For an example of how a regulator may tailor this language to their particular needs, see [SFMTA’s scooter permit language](https://www.sfmta.com/sites/default/files/reports-and-documents/2021/08/2021_scooter_permit_terms_and_conditions_and_appendices_final_for_permit-lime.pdf) (beginning on page 41).
 
 ## Additional considerations
-The value of open mobility data can only be fully realized when that data is easily accessible to the public and traveler privacy is protected; GBFS is designed to support both. Cities and agencies should publish the locations of gbfs.json files on their websites or open data portals and on the [openly available dataset catalog](https://github.com/NABSA/gbfs/blob/master/systems.csv) connected to GBFS.
+The value of open mobility data can only be fully realized when that data is easily accessible to the public and traveler privacy is protected; GBFS is designed to support both. Cities and agencies should publish the locations of gbfs.json files on their websites or open data portals and on the [openly available dataset catalog](https://github.com/MobilityData/gbfs/blob/master/systems.csv) connected to GBFS.
 
 Requesting open data from shared mobility operators will become even more crucial in the upcoming years as the European Commission enforces the obligation for each Member State to set a National Access Point (NAP) acting as a portal to all open data in regards to mobility services and all consumer-facing information. NAPs are designed to support a thriving European ecosystem built on interoperability between mobility modes and regions, reinforcing the ability of any consumer to travel seamlessly within the European Union. GBFS is a common and accepted format that allows countries to comply with the European regulations on several levels:
 
@@ -199,7 +199,7 @@ GBFS is the only open data standard, used internationally, to be recognized by C
 
 ## Useful links
 
-* [GBFS Repo on GitHub](https://github.com/NABSA/gbfs)
+* [GBFS Repo on GitHub](https://github.com/MobilityData/gbfs)
 * [GBFS Public Slack Channel](https://share.mobilitydata.org/slack)
 * [NeTEx](https://data4pt.org/wiki/NeTEX)
 * [SIRI](https://data4pt.org/wiki/SIRI)

--- a/docs/learn/white-papers/data-policy.md
+++ b/docs/learn/white-papers/data-policy.md
@@ -42,7 +42,7 @@ Your tender should require a publicly accessible GBFS API and should set expecta
 
 >**_Data sharing requirements:_**
 >
->* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/NABSA/gbfs/](https://github.com/NABSA/gbfs/blob/master/gbfs.md)._
+>* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
 >* _The GBFS API must be available to the public on the open internet without requiring authentication._
 
 ### Determine What Data to Require in a Comprehensive Policy.
@@ -154,7 +154,7 @@ At minimum, a shared mobility data policy should:
 
 **Sample policy language**
 
->_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/NABSA/gbfs/](https://github.com/NABSA/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
+>_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
 >
 >_[COMPANY] shall inform [PERMITTING AGENCY] of the URL for the gbfs.json endpoint prior to deploying vehicles. [COMPANY] must notify [PERMITTING AGENCY] at least 30 days prior to changing the URL of the gbfs.json endpoint._
 >
@@ -177,12 +177,12 @@ At minimum, a shared mobility data policy should:
 For an example of how a regulator may tailor this language to their particular needs, see [SFMTA’s scooter permit language](https://www.sfmta.com/sites/default/files/reports-and-documents/2021/08/2021_scooter_permit_terms_and_conditions_and_appendices_final_for_permit-lime.pdf) (beginning on page 41).
 
 ## Additional Considerations
-The value of open mobility data can only be fully realized when that data is easily accessible to the public. Cities and agencies should publish the locations of gbfs.json files on their websites or open data portals and on the [openly available dataset catalogue](https://github.com/NABSA/gbfs/blob/master/systems.csv) connected to GBFS.
+The value of open mobility data can only be fully realized when that data is easily accessible to the public. Cities and agencies should publish the locations of gbfs.json files on their websites or open data portals and on the [openly available dataset catalogue](https://github.com/MobilityData/gbfs/blob/master/systems.csv) connected to GBFS.
 
 GBFS has been developed and tested under a consensus model to ensure that data defined in the specification will not negatively impact user privacy. Extreme care should be taken when requiring data from operators that is outside the scope of the specification. (The over-collection of data — collecting data without a defined purpose — is strongly discouraged. Combining shared mobility data with other publicly available datasets could have serious privacy implications.) Data regarding vehicles that are part of an active rental should never appear in GBFS feeds.
 
 ## **Useful links**
-* [GBFS Repo on GitHub](https://github.com/NABSA/gbfs)
+* [GBFS Repo on GitHub](https://github.com/MobilityData/gbfs)
 * [GBFS Public Slack Channel](https://share.mobilitydata.org/slack)
 
 MobilityData Shared Mobility team email: <sharedmobility@mobilitydata.org>

--- a/docs/learn/white-papers/data-policy.md
+++ b/docs/learn/white-papers/data-policy.md
@@ -42,7 +42,7 @@ Your tender should require a publicly accessible GBFS API and should set expecta
 
 >**_Data sharing requirements:_**
 >
->* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
+>* _A publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
 >* _The GBFS API must be available to the public on the open internet without requiring authentication._
 
 ### Determine What Data to Require in a Comprehensive Policy.
@@ -154,7 +154,7 @@ At minimum, a shared mobility data policy should:
 
 **Sample policy language**
 
->_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at[ https://github.com/MobilityData/gbfs/](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
+>_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
 >
 >_[COMPANY] shall inform [PERMITTING AGENCY] of the URL for the gbfs.json endpoint prior to deploying vehicles. [COMPANY] must notify [PERMITTING AGENCY] at least 30 days prior to changing the URL of the gbfs.json endpoint._
 >

--- a/docs/toolbox/index.md
+++ b/docs/toolbox/index.md
@@ -6,7 +6,7 @@
 <ul>
 <li><a href="https://gbfs-validator.mobilitydata.org/"><strong>GBFS Validator</strong></a> - The Canonical GBFS Validator is a tool to check the conformity of a GBFS feed against the official specification including past releases and release candidates.</li>
 <li><a href="https://github.com/MobilityData/gbfs-json-schema"><strong>JSON Schemas</strong></a> - A set of JSON schemas is available for each version of the specification as well as the current release candidate. The Canonical GBFS Validator is based on these schemas.</li>
-<li><a href="https://github.com/NABSA/gbfs/blob/master/systems.csv"><strong>Dataset Catalog</strong></a> -  There are now over 900 shared mobility systems publishing GBFS worldwide. A catalog of these GBFS feeds is maintained by the GBFS community on the GBFS repo. This is an incomplete list. If you have or are aware of a feed that does not appear on the list please add it.</li>
+<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Dataset Catalog</strong></a> -  There are now over 900 shared mobility systems publishing GBFS worldwide. A catalog of these GBFS feeds is maintained by the GBFS community on the GBFS repo. This is an incomplete list. If you have or are aware of a feed that does not appear on the list please add it.</li>
 </ul></div>
 
 <!-- <div data-tf-popover="BCiwESfg" data-tf-button-color="#294774" data-tf-button-text="Launch me" data-tf-iframe-props="title=GBFS Documentation Platform Feedback" data-tf-medium="snippet" style="all:unset;"></div><script src="//embed.typeform.com/next/embed.js"></script> -->

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -2,6 +2,6 @@
 
 version=v2.2
 
-curl https://raw.githubusercontent.com/NABSA/gbfs/$version/gbfs.md -o docs/reference.md
+curl https://raw.githubusercontent.com/MobilityData/gbfs/$version/gbfs.md -o docs/reference.md
 
 # echo -e "\n\ntest" >> ../docs/*.md


### PR DESCRIPTION
## Problem
Some repo URLs were still pointing to the old NABSA repo.

## Solution
Update repo URLs from NABSA to MobilityData.

Before | After
-- | --
https://github.com/NABSA/gbfs | https://github.com/MobilityData/gbfs/