### PR TITLE
Removed `mkdocs-i18n==0.4.6`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ mkdocs-static-i18n==1.1.0
 mkdocs-simple-hooks>=0.1.5
 mkdocs-redirects==1.2.1
 mkdocs-embed-external-markdown==3.0.1
-mkdocs-i18n==0.4.6


### PR DESCRIPTION
No need for it, `mkdocs-static-i18n==1.1.0` does the same job. Probably even conflicts with it.