### PR TITLE
Update feedback form URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To edit the General Bikeshare Feed Specification reference, go to the [MobilityD
 
 To propose a feature, content addition, or UI/UX improvement, open an [issue](https://github.com/MobilityData/gbfs.org/issues/new) or [pull request](https://github.com/MobilityData/gbfs.org/pulls) on this repository. 
 
-Alternatively, you can provide feedback using this [form](https://mobilitydata.typeform.com/to/BCiwESfg).
+Alternatively, you can provide feedback using this [form](https://form.typeform.com/to/BCiwESfg).
 
 ### Contributing translations
 


### PR DESCRIPTION
The URL to submit feedback about gbfs.org was changed by typeform. 

This PR updates the typeform URL in the README.

Before | After
-- | --
<img width="1800" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/4e85d393-2634-4f67-829f-7c968b087083"> | <img width="1800" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/3cc5956b-ce07-4001-a9ea-7fa4a57b439a">