### PR TITLE
Replace roadmap with GBFS-only Productboard portal

### DIFF
--- a/docs/en/participate.md
+++ b/docs/en/participate.md
@@ -20,11 +20,7 @@ All change proposals are subject to the GBFS governance process.
 This road map has been developed based on feedback we have received from the GBFS community and shared mobility industry. If there are features or changes that you think should be part of this roadmap we'd like to hear about them. GBFS is an open project and we value your input.
 If you would like to contribute to the project please use the **Submit idea** button or get in touch with us at [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org) to coordinate contribution.
 
-<iframe src="https://portal.productboard.com/vejjy7p1a6gzdqbs2ev2ztn6?hide_logo=1" frameborder="0" height=500px width=100%></iframe>
-<hr>
-<iframe src="https://portal.productboard.com/xcpvceqebovhprgzprgr2ryb?hide_logo=1" frameborder="0" height=500px width=100%></iframe>
-
-<hr>
+<iframe src="https://portal.productboard.com/26qpteg4wct9px3jts94uqv8?hide_logo=1" frameborder="0" height=700px width=100%></iframe>
 
 ## Comments and Questions
 

--- a/docs/fr/participate.md
+++ b/docs/fr/participate.md
@@ -20,11 +20,7 @@ Toutes les propositions de modification sont soumises au processus de gouvernanc
 
 Cette feuille de route a été élaborée sur la base des commentaires que nous avons reçus de la communauté GBFS et de l'industrie de la mobilité partagée. Si vous pensez qu'il y a des fonctionnalités ou des changements qui devraient faire partie de cette feuille de route, nous aimerions les connaître. Si vous souhaitez contribuer au projet, veuillez utiliser le bouton " **Submit idea"** ou nous contacter à l'adresse <sharedmobility@mobilitydata.org> pour coordonner votre contribution.
 
-<iframe src="https://portal.productboard.com/vejjy7p1a6gzdqbs2ev2ztn6?hide_logo=1" frameborder="0" height=500px width=100%></iframe>
-<hr>
-<iframe src="https://portal.productboard.com/xcpvceqebovhprgzprgr2ryb?hide_logo=1" frameborder="0" height=500px width=100%></iframe>
-
-<hr/>
+<iframe src="https://portal.productboard.com/26qpteg4wct9px3jts94uqv8?hide_logo=1" frameborder="0" height=700px width=100%></iframe>
 
 ## Commentaires et questions
 


### PR DESCRIPTION
This PR replaces the roadmap with GBFS-only features from the Productboard portal.

Which pages are affected by this change?

- https://gbfs.org/participate/
- https://gbfs.org/fr/participate/

Before | After
-- | --
<img width="1800" alt="Screenshot 2024-02-28 at 13 02 59" src="https://github.com/MobilityData/gbfs.org/assets/2423604/441824e6-eb8b-4c76-bdba-6b34ea5641c6"> | <img width="1800" alt="Screenshot 2024-02-28 at 13 05 27" src="https://github.com/MobilityData/gbfs.org/assets/2423604/f719e26a-e24f-4969-a4e3-a28b1d02a486">