### PR TITLE
Add first adopters

### DIFF
--- a/docs/en/specification/index.md
+++ b/docs/en/specification/index.md
@@ -26,8 +26,8 @@ To support this process and ensure it is as timely as possible, MobilityData tra
 ### First Adopters
 🎉 Shoutout to the first adopters! These organizations invest a large amount of time and energy to implement the changes contained in the Release Candidate and make sure that GBFS continues to evolve.
 
-- Producers: [Check](https://ridecheck.app/en), [Flamingo](https://flamingoscooters.com/), [TIER](https://www.tier.app/).
-- Consumers: [ENTUR](https://entur.no/), [Transit](https://transitapp.com/?lang=fr), [transport.data.gouv.fr](https://transport.data.gouv.fr/), [Where To?](https://www.whereto.app/).
+- Producers: [Check](https://ridecheck.app/en), [ENTUR](https://entur.no/), [Flamingo](https://flamingoscooters.com/), [TIER](https://www.tier.app/).
+- Consumers: [Dashboard Deelmobiliteit](https://dashboarddeelmobiliteit.nl/), [ENTUR](https://entur.no/), [Transit](https://transitapp.com/), [transport.data.gouv.fr](https://transport.data.gouv.fr/), [Where To?](https://www.whereto.app/).
 ### Implementation Status
 The following items have passed through the voting process and will be included in the next version.
 <iframe class="airtable-embed" src="https://airtable.com/embed/appQvTu1nOy6fJwUP/shrNl0TSZGrqD3REa?backgroundColor=red&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="633" style="background: transparent; border: 1px solid #ccc;"></iframe>

--- a/docs/fr/specification/index.md
+++ b/docs/fr/specification/index.md
@@ -28,8 +28,8 @@ Pour soutenir ce processus et s'assurer qu'il est aussi rapide que possible, Mob
 
 🎉 Bravo aux premiers adoptant·es ! Ces organisations investissent beaucoup de temps et d'énergie pour mettre en œuvre les changements contenus dans la version candidate et s'assurer que le GBFS continue d'évoluer.
 
-- Producteurs : [Check](https://ridecheck.app/en), [Flamingo](https://flamingoscooters.com/), [TIER](https://www.tier.app/).
-- Applications réutilisatrices : [ENTUR](https://entur.no/), [Transit](https://transitapp.com/?lang=fr), [transport.data.gouv.fr](https://transport.data.gouv.fr/), [Where To ?](https://www.whereto.app/)
+- Producteurs : [Check](https://ridecheck.app/en), [ENTUR](https://entur.no/), [Flamingo](https://flamingoscooters.com/), [TIER](https://www.tier.app/).
+- Applications réutilisatrices : [Dashboard Deelmobiliteit](https://dashboarddeelmobiliteit.nl/), [ENTUR](https://entur.no/), [Transit](https://transitapp.com/?lang=fr), [transport.data.gouv.fr](https://transport.data.gouv.fr/), [Where To?](https://www.whereto.app/).
 
 ### Statut de l'implémentation
 


### PR DESCRIPTION
This PR adds [Dashboard Deelmobiliteit](https://dashboarddeelmobiliteit.nl/) and [ENTUR](https://entur.no/) as first adopters on https://gbfs.org/specification/#first-adopters.

Before | After
-- | --
<img width="716" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/d71e69f0-d836-4b05-bf14-f052b75bab9c"> | <img width="773" alt="Screenshot 2024-03-01 at 14 59 14" src="https://github.com/MobilityData/gbfs.org/assets/2423604/36e85f91-7b16-4c97-a770-621bd8fbcde4">