### PR TITLE
Fix relative URLs in reference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-material==9.4.4
 mkdocs-static-i18n==1.1.0
 mkdocs-simple-hooks>=0.1.5
 mkdocs-redirects==1.2.1
-mkdocs-embed-external-markdown==3.0.1
+mkdocs-embed-external-markdown==2.3.0


### PR DESCRIPTION
## Problem
When clicking an anchor in the Table of Contents of the reference on https://gbfs.org/specification/reference/, the links redirect to the raw content on GitHub.

## Solution
This PR fixes anchors in the reference. 

The reference is fetched by the plugin [mkdocs-embed-external-markdown](https://pypi.org/project/mkdocs-embed-external-markdown/). The plugin [change log](https://github.com/fire1ce/mkdocs-embed-external-markdown?tab=readme-ov-file#changelog) shows that version `3.x.x`:
>Added handling for relative links in the markdown, making them absolute based on the base URL.

We want the relative links to remain relative. So this PR downgrades the plugin to the version preceding this change: `2.3.0`.

**Before**

https://github.com/MobilityData/gbfs.org/assets/2423604/70f34b7b-e1be-4a46-8b63-c2f932ce3850

**After**

https://github.com/MobilityData/gbfs.org/assets/2423604/80abbd14-88f9-4701-aecc-ad55bd83ecbd