### PR TITLE
Fix number of JSON files in a GBFS v3 dataset

### DIFF
--- a/docs/en/learn/guide.md
+++ b/docs/en/learn/guide.md
@@ -71,7 +71,7 @@ Next, you will need to model the data into the GBFS structure.
 
 <img src="../../img/gbfs_structure.png" width="600px" alt="GBFS structure">
 
-_A GBFS dataset can be composed of 13 JSON files, some always required, some required under certain conditions and others optional. The [manifest.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#manifestjson) file lists the auto-discovery URLs for each GBFS dataset produced by a publisher._
+_A GBFS v3 dataset is composed of 12 JSON files, some always required, some required under certain conditions and others optional. The [manifest.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#manifestjson) file lists the auto-discovery URLs for each GBFS dataset produced by a publisher._
 
 This structure was designed to separate real-time information (eg: [station_status.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_statusjson) and [vehicle_status.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_statusjson)) from static information (eg: [system_information.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_informationjson), [station_information.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_informationjson) and [vehicle_types.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_typesjson)). This makes it possible to have a longer cache duration for information that changes less often.
 

--- a/docs/fr/learn/guide.md
+++ b/docs/fr/learn/guide.md
@@ -70,7 +70,7 @@ Ensuite, vous devrez modéliser les données dans la structure GBFS.
 
 <img src="../../../img/gbfs_structure.png" width="600px" alt="GBFS structure"/>
 
-_Un jeu de données GBFS peut être composé de 13 fichiers JSON, certains toujours obligatoires, d'autres obligatoires sous certaines conditions et d'autres optionnels. Le fichier [manifest.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#manifestjson) énumère les URL pour chaque jeu de données GBFS produit par un éditeur._
+_Un jeu de données GBFS v3 est composé de 12 fichiers JSON, certains toujours obligatoires, d'autres obligatoires sous certaines conditions et d'autres optionnels. Le fichier [manifest.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#manifestjson) énumère les URL pour chaque jeu de données GBFS produit par un éditeur._
 
 Cette structure a été conçue pour séparer les informations en temps réel (ex : [station_status.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_statusjson) et [vehicle_status.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_statusjson)) des informations statiques (ex : [system_information.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_informationjson), [station_information.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_informationjson) et [vehicle_types.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_typesjson)). Cela permet d'avoir une durée de cache plus longue pour les informations qui changent moins souvent.
 


### PR DESCRIPTION
This PR fixes a typo in the GBFS Implementation guide (https://gbfs.org/learn/guide/).

A GBFS v3 dataset is composed of up to 12 JSON files. Previous versions were composed of up to 13 files.

Before | After
-- | --
<img width="607" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/1912a34a-2cac-44c7-8850-1791e76205e6"> | <img width="609" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/e8eb3445-ff39-407b-9b4f-c92f25bd9fed">