### PR TITLE
Fix redirects

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,11 +79,11 @@ plugins:
       lang: en
   - redirects:
       redirect_maps:
-        'home.md': 'en/index.md'
+        'home.md': 'index.md'
         'major-change-proposals.md': 'https://github.com/MobilityData/gbfs/issues'
-        'tools-services.md': 'en/toolbox/index.md'
-        'faq.md': 'en/learn/faq.md'
-        'about.md': 'en/participate.md'
+        'tools-services.md': 'toolbox/index.md'
+        'faq.md': 'learn/faq.md'
+        'about.md': 'participate.md'
   - external-markdown
   - i18n:
       docs_structure: folder


### PR DESCRIPTION
This PR fixes the redirect URLs.

The source of the problem seems to be from commit https://github.com/MobilityData/gbfs.org/pull/78/commits/a4586983628df0f59a2d58383fda368c41c9ed7f.

Before | After (could not test locally)
-- | --
<img width="530" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/d1480b83-331c-4f08-a8c7-9335df44bf6d"> | <img width="823" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/f52bffa7-c3e4-4323-ae43-e163f85ef737">

I suggest to merge and test this URL to see if the redirect is fixed: https://gbfs.org/faq should redirect to https://gbfs.org/learn/faq/.

Note that the proposed change generates a warning and I am not able to test locally :

<img width="1042" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/b67151a6-d596-4f42-876e-6c5c63a3dab6">