### PR TITLE
Update Implementation Guide to v3.0

### DIFF
--- a/docs/en/learn/guide.md
+++ b/docs/en/learn/guide.md
@@ -87,7 +87,7 @@ Example of [station_status.json](https://github.com/MobilityData/gbfs/blob/maste
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "stations": [
       {
@@ -131,7 +131,7 @@ Example of [vehicle_status.json](https://github.com/MobilityData/gbfs/blob/maste
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "vehicles": [
       {
@@ -165,7 +165,7 @@ To protect user privacy, vehicles in active rental should not be included in thi
 
 #### Use the Current Version of GBFS
 
-Use the [Current Version](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) of the specification to benefit from the most coverage of vehicle types and features. This guide uses version 3.0-RC of the GBFS specification. [Release Candidates](https://github.com/MobilityData/gbfs/wiki/Release-Candidate-Feature-Implementation) (-RC) are versions that will receive Current Version status when they have been fully implemented in public feeds.
+Use the [Current Version](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) of the specification to benefit from the most coverage of vehicle types and features. This guide uses version 3.0 of the GBFS specification. [Release Candidates](https://github.com/MobilityData/gbfs/blob/master/README.md#release-candidates) (-RC) are versions that will receive Current Version status when they have been fully implemented in public feeds.
 
 #### Generate a data model from the JSON schema
 

--- a/docs/en/learn/guide.md
+++ b/docs/en/learn/guide.md
@@ -8,12 +8,12 @@ This guide is intended for technical teams of shared mobility services. In this 
 
 The General Bikeshare Feed Specification (GBFS) was created in 2014 by [Mitch Vars](https://github.com/mplsmitch), which was then adopted by [NABSA](https://nabsa.net/), to standardize the way shared bike systems communicate with trip planning applications. 
 
-Powered by MobilityData since 2019 and officially transferred to MobilityData in 2022, GBFS has evolved to allow [over 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) docked and dockless systems worldwide such as scooters, mopeds and shared cars to appear in trip planning applications.
+Powered by MobilityData since 2019 and officially transferred to MobilityData in 2022, GBFS has evolved to allow [over 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) docked and dockless systems worldwide such as scooters, mopeds and shared cars to appear in trip planning applications.
 
 <img src="../../img/gbfs_producer_consumer_logos.png" width="1000px" alt="GBFS producer consumer logos">
 
 
-_GBFS is a standardized data format used by [over 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) shared mobility services worldwide to appear in trip planners and other consuming applications._
+_GBFS is a standardized data format used by [over 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) shared mobility services worldwide to appear in trip planners and other consuming applications._
 
 ## Overview of a GBFS feed
 

--- a/docs/en/specification/index.md
+++ b/docs/en/specification/index.md
@@ -1,15 +1,14 @@
 # Specification
 
 <div class="landing-page">
-    <a class="button" href="reference">Latest Reference (v3.0-RC2)</a><a class="button" href="https://github.com/MobilityData/gbfs/issues">Change Proposals</a><a class="button" href="process">Governance Process</a>
+    <a class="button" href="reference">Latest Reference (v3.0)</a><a class="button" href="https://github.com/MobilityData/gbfs/issues">Change Proposals</a><a class="button" href="process">Governance Process</a>
 </div>
 
 <hr>
 
 ## Versions of this documentation
 
-- [Latest](reference) - Version 3.0-RC2
-- [v3.0-RC](https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md) - Version 3.0-RC
+- [Latest](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2
 - [v2.1](https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md) - Version 2.1

--- a/docs/en/toolbox/index.md
+++ b/docs/en/toolbox/index.md
@@ -6,7 +6,7 @@
 <ul>
 <li><a href="https://gbfs-validator.mobilitydata.org/"><strong>GBFS Validator</strong></a> - The Canonical GBFS Validator is a tool to check the conformity of a GBFS feed against the official specification including past releases and release candidates.</li>
 <li><a href="https://github.com/MobilityData/gbfs-json-schema"><strong>JSON Schemas</strong></a> - A set of JSON schemas is available for each version of the specification as well as the current release candidate. The Canonical GBFS Validator is based on these schemas.</li>
-<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Dataset Catalog</strong></a> -  There are now over 900 shared mobility systems publishing GBFS worldwide. A catalog of these GBFS feeds is maintained by the GBFS community on the GBFS repo. This is an incomplete list. If you have or are aware of a feed that does not appear on the list please add it.</li>
+<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Dataset Catalog</strong></a> -  There are now over 800 shared mobility systems publishing GBFS worldwide. A catalog of these GBFS feeds is maintained by the GBFS community on the GBFS repo. This is an incomplete list. If you have or are aware of a feed that does not appear on the list please add it.</li>
 </ul></div>
 
 <!-- <div data-tf-popover="BCiwESfg" data-tf-button-color="#294774" data-tf-button-text="Launch me" data-tf-iframe-props="title=GBFS Documentation Platform Feedback" data-tf-medium="snippet" style="all:unset;"></div><script src="//embed.typeform.com/next/embed.js"></script> -->

--- a/docs/fr/learn/guide.md
+++ b/docs/fr/learn/guide.md
@@ -86,7 +86,7 @@ Exemple de fichier [station_status.json](https://github.com/MobilityData/gbfs/bl
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "stations": [
       {
@@ -130,7 +130,7 @@ Exemple de fichier [vehicle_status.json](https://github.com/MobilityData/gbfs/bl
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "vehicles": [
       {
@@ -164,7 +164,7 @@ Pour protéger la vie privée des utilisateur·rices, les véhicules en location
 
 #### Utiliser la version actuelle de GBFS
 
-Utilisez la [version actuelle](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) de la spécification pour bénéficier de la plus grande couverture des types de véhicules et de leurs caractéristiques. Ce guide utilise la version 3.0-RC de la spécification GBFS. Les versions [Release Candidate](https://github.com/MobilityData/gbfs/wiki/Release-Candidate-Feature-Implementation) (-RC) sont des versions qui recevront le statut de version actuelle lorsqu'elles auront été entièrement implémentées dans des flux publics.
+Utilisez la [version actuelle](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) de la spécification pour bénéficier de la plus grande couverture des types de véhicules et de leurs caractéristiques. Ce guide utilise la version 3.0 de la spécification GBFS. Les versions [Release Candidate](https://github.com/MobilityData/gbfs/blob/master/README.md#release-candidates) (-RC) sont des versions qui recevront le statut de version actuelle lorsqu'elles auront été entièrement implémentées dans des flux publics.
 
 #### Générer un modèle de données à partir du schéma JSON
 

--- a/docs/fr/learn/guide.md
+++ b/docs/fr/learn/guide.md
@@ -8,11 +8,11 @@ Ce guide est destiné aux équipes techniques des services de mobilité partagé
 
 Le General Bikeshare Feed Specification (GBFS) a été créé en 2014 par [Mitch Vars](https://github.com/mplsmitch), puis adopté par [NABSA](https://nabsa.net/), afin de standardiser la façon dont les systèmes de vélos en libre-service communiquent avec les applications de planification d'itinéraires.
 
-Maintenu par MobilityData depuis 2019 et officiellement transféré à MobilityData en 2022, GBFS a évolué pour permettre à [plus de 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) systèmes avec stations et free-floating dans le monde entier, tels que les trotinettes, les scooters et les voitures partagées, d'apparaître dans les applications de planification d'itinéraires.
+Maintenu par MobilityData depuis 2019 et officiellement transféré à MobilityData en 2022, GBFS a évolué pour permettre à [plus de 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) systèmes avec stations et free-floating dans le monde entier, tels que les trotinettes, les scooters et les voitures partagées, d'apparaître dans les applications de planification d'itinéraires.
 
 <img src="../../../img/gbfs_producer_consumer_logos.png" width="1000px" alt="GBFS producer consumer logos"/>
 
-_GBFS est un format de données standardisé utilisé par [plus de 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) services de mobilité partagée dans le monde pour apparaître dans les planificateurs d'itinéraires et autres applications réutilisatrices des données._
+_GBFS est un format de données standardisé utilisé par [plus de 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) services de mobilité partagée dans le monde pour apparaître dans les planificateurs d'itinéraires et autres applications réutilisatrices des données._
 
 ## Aperçu d'un flux GBFS
 

--- a/docs/fr/toolbox/index.md
+++ b/docs/fr/toolbox/index.md
@@ -6,7 +6,7 @@
 <ul>
 <li><a href="https://gbfs-validator.mobilitydata.org/"><strong>GBFS Validator</strong></a> - Le Canonical GBFS Validator est un outil permettant de vérifier la conformité d'un flux GBFS par rapport à la spécification officielle, y compris les versions antérieures et les versions candidates.</li>
 <li><a href="https://github.com/MobilityData/gbfs-json-schema"><strong>Schémas JSON</strong></a> - Un ensemble de schémas JSON est disponible pour chaque version de la spécification ainsi que pour la version candidate actuelle. Le validateur canonique GBFS est basé sur ces schémas.</li>
-<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Catalogue d'ensembles de données</strong></a> - Plus de 900 systèmes de mobilité partagée publient aujourd'hui des données GBFS dans le monde entier. Un catalogue de ces flux GBFS est maintenu par la communauté GBFS sur le repo GBFS. Cette liste est incomplète. Si vous avez ou connaissez un flux qui n'apparaît pas dans la liste, veuillez l'ajouter.</li>
+<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Catalogue d'ensembles de données</strong></a> - Plus de 800 systèmes de mobilité partagée publient aujourd'hui des données GBFS dans le monde entier. Un catalogue de ces flux GBFS est maintenu par la communauté GBFS sur le repo GBFS. Cette liste est incomplète. Si vous avez ou connaissez un flux qui n'apparaît pas dans la liste, veuillez l'ajouter.</li>
 </ul></div>
 
 <!-- <div data-tf-popover="BCiwESfg" data-tf-button-color="#294774" data-tf-button-text="Launch me" data-tf-iframe-props="title=GBFS Documentation Platform Feedback" data-tf-medium="snippet" style="all:unset;"></div><script src="//embed.typeform.com/next/embed.js"></script> -->


### PR DESCRIPTION
This PR updates the examples in the implementation guide to use v3.0.

It also set the number of systems to 800 after the catalog cleanup in https://github.com/MobilityData/gbfs/pull/622.