### PR TITLE
Update policy guides to v3.0

### DIFF
--- a/docs/en/learn/guide.md
+++ b/docs/en/learn/guide.md
@@ -87,7 +87,7 @@ Example of [station_status.json](https://github.com/MobilityData/gbfs/blob/maste
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "stations": [
       {
@@ -131,7 +131,7 @@ Example of [vehicle_status.json](https://github.com/MobilityData/gbfs/blob/maste
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "vehicles": [
       {
@@ -165,7 +165,7 @@ To protect user privacy, vehicles in active rental should not be included in thi
 
 #### Use the Current Version of GBFS
 
-Use the [Current Version](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) of the specification to benefit from the most coverage of vehicle types and features. This guide uses version 3.0-RC of the GBFS specification. [Release Candidates](https://github.com/MobilityData/gbfs/wiki/Release-Candidate-Feature-Implementation) (-RC) are versions that will receive Current Version status when they have been fully implemented in public feeds.
+Use the [Current Version](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) of the specification to benefit from the most coverage of vehicle types and features. This guide uses version 3.0 of the GBFS specification. [Release Candidates](https://github.com/MobilityData/gbfs/blob/master/README.md#release-candidates) (-RC) are versions that will receive Current Version status when they have been fully implemented in public feeds.
 
 #### Generate a data model from the JSON schema
 

--- a/docs/en/learn/guide.md
+++ b/docs/en/learn/guide.md
@@ -8,12 +8,12 @@ This guide is intended for technical teams of shared mobility services. In this 
 
 The General Bikeshare Feed Specification (GBFS) was created in 2014 by [Mitch Vars](https://github.com/mplsmitch), which was then adopted by [NABSA](https://nabsa.net/), to standardize the way shared bike systems communicate with trip planning applications. 
 
-Powered by MobilityData since 2019 and officially transferred to MobilityData in 2022, GBFS has evolved to allow [over 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) docked and dockless systems worldwide such as scooters, mopeds and shared cars to appear in trip planning applications.
+Powered by MobilityData since 2019 and officially transferred to MobilityData in 2022, GBFS has evolved to allow [over 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) docked and dockless systems worldwide such as scooters, mopeds and shared cars to appear in trip planning applications.
 
 <img src="../../img/gbfs_producer_consumer_logos.png" width="1000px" alt="GBFS producer consumer logos">
 
 
-_GBFS is a standardized data format used by [over 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) shared mobility services worldwide to appear in trip planners and other consuming applications._
+_GBFS is a standardized data format used by [over 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) shared mobility services worldwide to appear in trip planners and other consuming applications._
 
 ## Overview of a GBFS feed
 

--- a/docs/en/learn/white-papers/data-policy-europe.md
+++ b/docs/en/learn/white-papers/data-policy-europe.md
@@ -54,7 +54,8 @@ When developing data policies, it is a good idea to gather input from subject ma
 GBFS is designed to accommodate the needs of a wide variety of mobility platforms and use cases, from traditional docked bikeshare to free floating bikes, scooters, and other vehicles. The specification consists of thirteen files or endpoints that contain different types of mobility data. Some of these files and their associated fields are required in order to be compliant with the specification, while others are optional. Which of these files are required by the specification depends on the specific type of mobility system being represented. Optional files and fields provide additional data for specific purposes and use cases. Municipalities may need to require some of these optional files or fields in their regulations to provide additional information in support of travelers, municipal goals, or other needs.
 
 
-### Overview of GBFS files
+### Overview of GBFS Files
+
 <table>
   <tr>
    <td><strong>File  Name</strong>
@@ -66,6 +67,12 @@ GBFS is designed to accommodate the needs of a wide variety of mobility platform
    <td><strong>gbfs.json</strong>
    </td>
    <td><strong>Required</strong> – This file is an index of URLs for all other files published as part of a GBFS API.  To make data available to the public, a link to this file should be published on the city or agency website or open data portal. 
+   </td>
+  </tr>
+  <tr>
+   <td><strong>manifest.json</strong>
+   </td>
+   <td><strong>Optional</strong> – This file is an index of gbfs.json URLs for each GBFS data set produced by a publisher. 
    </td>
   </tr>
   <tr>
@@ -83,7 +90,7 @@ GBFS is designed to accommodate the needs of a wide variety of mobility platform
   <tr>
    <td><strong>vehicle_types.json</strong>
    </td>
-   <td><strong>Conditionally Required</strong> – This file is required of systems that include information about vehicle types in the free_bike_status file or its equivalent. This file should be published by systems offering multiple vehicle types for rental, for example pedal bikes and ebikes. If this file is not published, all vehicles in the feed are assumed to be non-motorized bicycles.  
+   <td><strong>Conditionally Required</strong> – This file is required of systems that include information about vehicle types in the vehicle_status file or its equivalent. This file should be published by systems offering multiple vehicle types for rental, for example pedal bikes and ebikes. If this file is not published, all vehicles in the feed are assumed to be non-motorized bicycles.  
    </td>
   </tr>
   <tr>
@@ -99,24 +106,11 @@ GBFS is designed to accommodate the needs of a wide variety of mobility platform
    </td>
   </tr>
   <tr>
-   <td><strong>free_bike_status.json</strong>
+   <td><strong>vehicle_status.json</strong>
    </td>
    <td><strong>Conditionally Required</strong> – This file (or its equivalent) is required for free floating (dockless) or hybrid (docked/dockless) vehicles. It is optional for station based (docked) vehicles. This is a real-time file that shows the current location, availability status, and other attributes of individual vehicles in a fleet. May optionally be used in station based (docked) systems to publish information on vehicle types, charge or fuel levels, and other vehicle attributes. This data may be used to determine the number of vehicles deployed, their availability for rental, and their distribution within the service area. 
    </td>
   </tr>
-  <tr>
-   <td><strong>system_hours.json</strong>
-   </td>
-   <td><strong>Optional</strong> – This file is used to indicate hours and days of operation when vehicles are available for rent. It should be required if the service is not available for 24 hours a day, 7 days a week. If this file is not published, it indicates that vehicles are available for rental 24/7. (This file may be deprecated in the future, in which case system hours should be published using the method described in the appropriate version.)
-   </td>
-  </tr>
-  <tr>
-   <td><strong>system_calendar.json</strong>
-   </td>
-   <td><strong>Optional</strong> – This optional file should be required of systems that operate seasonally or that do not offer continuous year-round service. (This file may be deprecated in the future in which case  system hours should be published using the method described in the appropriate version.)
-   </td>
-  </tr>
-  <tr>
    <td><strong>system_regions.json</strong>
    </td>
    <td><strong>Optional</strong> – This file is used to define regions within a system. It may be used to support reporting in systems that encompass multiple jurisdictions.
@@ -153,7 +147,9 @@ At minimum, a shared mobility data policy should:
 
 **Sample policy language**
 
->_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
+>_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
+>
+>_[COMPANY] must make the API available to the public on the open internet without requiring authentication._
 >
 >_[COMPANY] shall inform [PERMITTING AGENCY] of the URL for the gbfs.json endpoint prior to deploying vehicles. [COMPANY] must notify [PERMITTING AGENCY] at least 30 days prior to changing the URL of the gbfs.json endpoint._
 >
@@ -162,9 +158,10 @@ At minimum, a shared mobility data policy should:
 >_Upon release of a new version of GBFS, [COMPANY] must update API to the new version within [XX<sup>1</sup>] days unless prior arrangement has been made with [PERMITTING AGENCY]._
 >
 >_GBFS API must contain the following endpoints and all fields required under the GBFS specification:_
+>
 >* _gbfs.json_
 >* _system_information.json_
->* _[ list of additional endpoints e.g. station_information.json, station_status.json, free_bike status.json or its equivalent, etc.]_
+>* _[ list of additional endpoints e.g. station_information.json, station_status.json, vehicle_status.json or its equivalent, etc.]_
 >
 >_In addition to the fields required under the specification the following files must also contain these optional fields:_
 >
@@ -201,26 +198,14 @@ GBFS is the only open data standard, used internationally, to be recognized by C
 
 * [GBFS Repo on GitHub](https://github.com/MobilityData/gbfs)
 * [GBFS Public Slack Channel](https://share.mobilitydata.org/slack)
-* [NeTEx](https://data4pt.org/wiki/NeTEX)
-* [SIRI](https://data4pt.org/wiki/SIRI)
+* [NeTEx](https://data4pt.org/w/index.php?title=NeTEX)
+* [SIRI](https://data4pt.org/w/index.php?title=SIRI)
 
 MobilityData Shared Mobility team email: <sharedmobility@mobilitydata.org>
 
 ## Acknowledgements
 
-**Shared Mobility Team at MobilityData**
-
-[Heidi Guenin](https://www.linkedin.com/in/heidiguenin/) - Director, Product, Shared Mobility
-
-[Mitch Vars](https://www.linkedin.com/in/mitchvars/) - Senior, Shared Mobility Specialist
-
-[Josée Sabourin](https://www.linkedin.com/in/josee-sabourin/) - Shared Mobility Specialist
-
-**Partnerships, Europe at MobilityData**
-
-Tu-Tho Thai - Director, Partnerships Europe
-
-Newton Davis - Partnerships Europe
+[Heidi Guenin](https://www.linkedin.com/in/heidiguenin/), [Mitch Vars](https://www.linkedin.com/in/mitchvars/), [Josée Sabourin](https://www.linkedin.com/in/josee-sabourin/), [Tu-Tho Thai](https://www.linkedin.com/in/tuthothai/) and [Newton Davis](https://www.linkedin.com/in/newtondavis/).
 
 **Reviewers**
 

--- a/docs/en/learn/white-papers/data-policy.md
+++ b/docs/en/learn/white-papers/data-policy.md
@@ -14,6 +14,7 @@ Since it was first established in 2015, GBFS has become the de facto standard fo
 **Policymakers should require public GBFS APIs when permitting or licensing shared mobility operations.** 
 
 GBFS provides a common language for shared mobility operators to share information about options available to travelers. GBFS includes information about vehicles (bicycles, scooters, moped, and cars), stations, and more:
+
 * Vehicle, station, and dock locations and availability
 * Vehicle characteristics – type of power, distance that can be traveled on remaining charge
 * Geofenced areas for rules related to speed, parking, and prohibited zones
@@ -69,6 +70,12 @@ GBFS is designed to accommodate the needs of a wide variety of mobility platform
    </td>
   </tr>
   <tr>
+   <td><strong>manifest.json</strong>
+   </td>
+   <td><strong>Optional</strong> – This file is an index of gbfs.json URLs for each GBFS data set produced by a publisher. 
+   </td>
+  </tr>
+  <tr>
    <td><strong>gbfs_versions.json</strong>
    </td>
    <td><strong>Optional</strong> – This file lists all files published by the operator according to their versions. Maintaining feeds in past versions as new versions of GBFS become available may prevent breaking of downstream applications.
@@ -83,7 +90,7 @@ GBFS is designed to accommodate the needs of a wide variety of mobility platform
   <tr>
    <td><strong>vehicle_types.json</strong>
    </td>
-   <td><strong>Conditionally Required</strong> – This file is required of systems that include information about vehicle types in the free_bike_status file or its equivalent. This file should be published by systems offering multiple vehicle types for rental, for example pedal bikes and ebikes. If this file is not published, all vehicles in the feed are assumed to be non-motorized bicycles.  
+   <td><strong>Conditionally Required</strong> – This file is required of systems that include information about vehicle types in the vehicle_status file or its equivalent. This file should be published by systems offering multiple vehicle types for rental, for example pedal bikes and ebikes. If this file is not published, all vehicles in the feed are assumed to be non-motorized bicycles.  
    </td>
   </tr>
   <tr>
@@ -99,24 +106,11 @@ GBFS is designed to accommodate the needs of a wide variety of mobility platform
    </td>
   </tr>
   <tr>
-   <td><strong>free_bike_status.json</strong>
+   <td><strong>vehicle_status.json</strong>
    </td>
    <td><strong>Conditionally Required</strong> – This file (or its equivalent) is required for free floating (dockless) or hybrid (docked/dockless) vehicles. It is optional for station based (docked) vehicles. This is a real-time file that shows the current location, availability status, and other attributes of individual vehicles in a fleet. May optionally be used in station based (docked) systems to publish information on vehicle types, charge or fuel levels, and other vehicle attributes. This data may be used to determine the number of vehicles deployed, their availability for rental, and their distribution within the service area. 
    </td>
   </tr>
-  <tr>
-   <td><strong>system_hours.json</strong>
-   </td>
-   <td><strong>Optional</strong> – This file is used to indicate hours and days of operation when vehicles are available for rent. It should be required if the service is not available for 24 hours a day, 7 days a week. If this file is not published, it indicates that vehicles are available for rental 24/7. (This file may be deprecated in the future, in which case system hours should be published using the method described in the appropriate version.)
-   </td>
-  </tr>
-  <tr>
-   <td><strong>system_calendar.json</strong>
-   </td>
-   <td><strong>Optional</strong> – This optional file should be required of systems that operate seasonally or that do not offer continuous year-round service. (This file may be deprecated in the future in which case  system hours should be published using the method described in the appropriate version.)
-   </td>
-  </tr>
-  <tr>
    <td><strong>system_regions.json</strong>
    </td>
    <td><strong>Optional</strong> – This file is used to define regions within a system. It may be used to support reporting in systems that encompass multiple jurisdictions.
@@ -154,7 +148,9 @@ At minimum, a shared mobility data policy should:
 
 **Sample policy language**
 
->_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) . [COMPANY] must make the API available to the public on the open internet without requiring authentication._
+>_[COMPANY] shall provide a publicly accessible API that conforms to the General Bikeshare Feed Specification (GBFS) current version available at [https://github.com/MobilityData/gbfs](https://github.com/MobilityData/gbfs/blob/master/gbfs.md)._
+>
+>_[COMPANY] must make the API available to the public on the open internet without requiring authentication._
 >
 >_[COMPANY] shall inform [PERMITTING AGENCY] of the URL for the gbfs.json endpoint prior to deploying vehicles. [COMPANY] must notify [PERMITTING AGENCY] at least 30 days prior to changing the URL of the gbfs.json endpoint._
 >
@@ -163,9 +159,10 @@ At minimum, a shared mobility data policy should:
 >_Upon release of a new version of GBFS, [COMPANY] must update API to the new version within [XX<sup>1</sup>] days unless prior arrangement has been made with [PERMITTING AGENCY]._
 >
 >_GBFS API must contain the following endpoints and all fields required under the GBFS specification:_
+>
 >* _gbfs.json_
 >* _system_information.json_
->* _[ list of additional endpoints e.g. station_information.json, station_status.json, free_bike status.json or its equivalent, etc.]_
+>* _[ list of additional endpoints e.g. station_information.json, station_status.json, vehicle_status.json or its equivalent, etc.]_
 >
 >_In addition to the fields required under the specification the following files must also contain these optional fields:_
 >
@@ -189,13 +186,7 @@ MobilityData Shared Mobility team email: <sharedmobility@mobilitydata.org>
 
 ## **Acknowledgement**
 
-**Shared Mobility Team at MobilityData**
-
-[Heidi Guenin](https://www.linkedin.com/in/heidiguenin/) - Director, Product, Shared Mobility
-
-[Mitch Vars](https://www.linkedin.com/in/mitchvars/) - Senior, Shared Mobility Specialist
-
-[Josée Sabourin](https://www.linkedin.com/in/josee-sabourin/) - Shared Mobility Specialist
+[Heidi Guenin](https://www.linkedin.com/in/heidiguenin/), [Mitch Vars](https://www.linkedin.com/in/mitchvars/) and [Josée Sabourin](https://www.linkedin.com/in/josee-sabourin/).
 
 **Reviewers**
 

--- a/docs/en/specification/index.md
+++ b/docs/en/specification/index.md
@@ -1,15 +1,14 @@
 # Specification
 
 <div class="landing-page">
-    <a class="button" href="reference">Latest Reference (v3.0-RC2)</a><a class="button" href="https://github.com/MobilityData/gbfs/issues">Change Proposals</a><a class="button" href="process">Governance Process</a>
+    <a class="button" href="reference">Latest Reference (v3.0)</a><a class="button" href="https://github.com/MobilityData/gbfs/issues">Change Proposals</a><a class="button" href="process">Governance Process</a>
 </div>
 
 <hr>
 
 ## Versions of this documentation
 
-- [Latest](reference) - Version 3.0-RC2
-- [v3.0-RC](https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md) - Version 3.0-RC
+- [Latest](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2
 - [v2.1](https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md) - Version 2.1

--- a/docs/en/toolbox/index.md
+++ b/docs/en/toolbox/index.md
@@ -6,7 +6,7 @@
 <ul>
 <li><a href="https://gbfs-validator.mobilitydata.org/"><strong>GBFS Validator</strong></a> - The Canonical GBFS Validator is a tool to check the conformity of a GBFS feed against the official specification including past releases and release candidates.</li>
 <li><a href="https://github.com/MobilityData/gbfs-json-schema"><strong>JSON Schemas</strong></a> - A set of JSON schemas is available for each version of the specification as well as the current release candidate. The Canonical GBFS Validator is based on these schemas.</li>
-<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Dataset Catalog</strong></a> -  There are now over 900 shared mobility systems publishing GBFS worldwide. A catalog of these GBFS feeds is maintained by the GBFS community on the GBFS repo. This is an incomplete list. If you have or are aware of a feed that does not appear on the list please add it.</li>
+<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Dataset Catalog</strong></a> -  There are now over 800 shared mobility systems publishing GBFS worldwide. A catalog of these GBFS feeds is maintained by the GBFS community on the GBFS repo. This is an incomplete list. If you have or are aware of a feed that does not appear on the list please add it.</li>
 </ul></div>
 
 <!-- <div data-tf-popover="BCiwESfg" data-tf-button-color="#294774" data-tf-button-text="Launch me" data-tf-iframe-props="title=GBFS Documentation Platform Feedback" data-tf-medium="snippet" style="all:unset;"></div><script src="//embed.typeform.com/next/embed.js"></script> -->

--- a/docs/fr/learn/guide.md
+++ b/docs/fr/learn/guide.md
@@ -86,7 +86,7 @@ Exemple de fichier [station_status.json](https://github.com/MobilityData/gbfs/bl
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "stations": [
       {
@@ -130,7 +130,7 @@ Exemple de fichier [vehicle_status.json](https://github.com/MobilityData/gbfs/bl
 {
   "last_updated": "2023-07-30T13:45:29+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0",
   "data": {
     "vehicles": [
       {
@@ -164,7 +164,7 @@ Pour protéger la vie privée des utilisateur·rices, les véhicules en location
 
 #### Utiliser la version actuelle de GBFS
 
-Utilisez la [version actuelle](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) de la spécification pour bénéficier de la plus grande couverture des types de véhicules et de leurs caractéristiques. Ce guide utilise la version 3.0-RC de la spécification GBFS. Les versions [Release Candidate](https://github.com/MobilityData/gbfs/wiki/Release-Candidate-Feature-Implementation) (-RC) sont des versions qui recevront le statut de version actuelle lorsqu'elles auront été entièrement implémentées dans des flux publics.
+Utilisez la [version actuelle](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended) de la spécification pour bénéficier de la plus grande couverture des types de véhicules et de leurs caractéristiques. Ce guide utilise la version 3.0 de la spécification GBFS. Les versions [Release Candidate](https://github.com/MobilityData/gbfs/blob/master/README.md#release-candidates) (-RC) sont des versions qui recevront le statut de version actuelle lorsqu'elles auront été entièrement implémentées dans des flux publics.
 
 #### Générer un modèle de données à partir du schéma JSON
 

--- a/docs/fr/learn/guide.md
+++ b/docs/fr/learn/guide.md
@@ -8,11 +8,11 @@ Ce guide est destiné aux équipes techniques des services de mobilité partagé
 
 Le General Bikeshare Feed Specification (GBFS) a été créé en 2014 par [Mitch Vars](https://github.com/mplsmitch), puis adopté par [NABSA](https://nabsa.net/), afin de standardiser la façon dont les systèmes de vélos en libre-service communiquent avec les applications de planification d'itinéraires.
 
-Maintenu par MobilityData depuis 2019 et officiellement transféré à MobilityData en 2022, GBFS a évolué pour permettre à [plus de 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) systèmes avec stations et free-floating dans le monde entier, tels que les trotinettes, les scooters et les voitures partagées, d'apparaître dans les applications de planification d'itinéraires.
+Maintenu par MobilityData depuis 2019 et officiellement transféré à MobilityData en 2022, GBFS a évolué pour permettre à [plus de 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) systèmes avec stations et free-floating dans le monde entier, tels que les trotinettes, les scooters et les voitures partagées, d'apparaître dans les applications de planification d'itinéraires.
 
 <img src="../../../img/gbfs_producer_consumer_logos.png" width="1000px" alt="GBFS producer consumer logos"/>
 
-_GBFS est un format de données standardisé utilisé par [plus de 900](https://github.com/MobilityData/gbfs/blob/master/systems.csv) services de mobilité partagée dans le monde pour apparaître dans les planificateurs d'itinéraires et autres applications réutilisatrices des données._
+_GBFS est un format de données standardisé utilisé par [plus de 800](https://github.com/MobilityData/gbfs/blob/master/systems.csv) services de mobilité partagée dans le monde pour apparaître dans les planificateurs d'itinéraires et autres applications réutilisatrices des données._
 
 ## Aperçu d'un flux GBFS
 

--- a/docs/fr/toolbox/index.md
+++ b/docs/fr/toolbox/index.md
@@ -6,7 +6,7 @@
 <ul>
 <li><a href="https://gbfs-validator.mobilitydata.org/"><strong>GBFS Validator</strong></a> - Le Canonical GBFS Validator est un outil permettant de vérifier la conformité d'un flux GBFS par rapport à la spécification officielle, y compris les versions antérieures et les versions candidates.</li>
 <li><a href="https://github.com/MobilityData/gbfs-json-schema"><strong>Schémas JSON</strong></a> - Un ensemble de schémas JSON est disponible pour chaque version de la spécification ainsi que pour la version candidate actuelle. Le validateur canonique GBFS est basé sur ces schémas.</li>
-<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Catalogue d'ensembles de données</strong></a> - Plus de 900 systèmes de mobilité partagée publient aujourd'hui des données GBFS dans le monde entier. Un catalogue de ces flux GBFS est maintenu par la communauté GBFS sur le repo GBFS. Cette liste est incomplète. Si vous avez ou connaissez un flux qui n'apparaît pas dans la liste, veuillez l'ajouter.</li>
+<li><a href="https://github.com/MobilityData/gbfs/blob/master/systems.csv"><strong>Catalogue d'ensembles de données</strong></a> - Plus de 800 systèmes de mobilité partagée publient aujourd'hui des données GBFS dans le monde entier. Un catalogue de ces flux GBFS est maintenu par la communauté GBFS sur le repo GBFS. Cette liste est incomplète. Si vous avez ou connaissez un flux qui n'apparaît pas dans la liste, veuillez l'ajouter.</li>
 </ul></div>
 
 <!-- <div data-tf-popover="BCiwESfg" data-tf-button-color="#294774" data-tf-button-text="Launch me" data-tf-iframe-props="title=GBFS Documentation Platform Feedback" data-tf-medium="snippet" style="all:unset;"></div><script src="//embed.typeform.com/next/embed.js"></script> -->


### PR DESCRIPTION
This PR updates the policy guides to v3.0:
- https://gbfs.org/learn/white-papers/data-policy/
- https://gbfs.org/learn/white-papers/data-policy-europe/