### PR TITLE
Add v3.1-RC to the list of versions

### DIFF
--- a/docs/en/specification/index.md
+++ b/docs/en/specification/index.md
@@ -8,6 +8,7 @@
 
 ## Versions of this documentation
 
+- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC/gbfs.md) - Version 3.1-RC
 - [Latest](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2

--- a/docs/en/specification/reference.md
+++ b/docs/en/specification/reference.md
@@ -1,2 +1,2 @@
 # General Bikeshare Feed Specification (GBFS)
-{{ external_markdown('https://raw.githubusercontent.com/MobilityData/gbfs/master/gbfs.md', '') }}
+{{ external_markdown('https://raw.githubusercontent.com/MobilityData/gbfs/v3.0/gbfs.md', '') }}

--- a/docs/fr/specification/index.md
+++ b/docs/fr/specification/index.md
@@ -8,6 +8,7 @@
 
 ## Versions de cette documentation
 
+- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC/gbfs.md) - Version 3.1-RC
 - [Version actuelle](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2

--- a/docs/fr/specification/index.md
+++ b/docs/fr/specification/index.md
@@ -1,15 +1,14 @@
 # Spécification
 
 <div class="landing-page">
-   <a class="button" href="reference">Version actuelle (v3.0-RC2)</a><a class="button" href="https://github.com/MobilityData/gbfs/issues">Propositions de modification</a><a class="button" href="process">Processus de gouvernance</a>
+   <a class="button" href="reference">Version actuelle (v3.0)</a><a class="button" href="https://github.com/MobilityData/gbfs/issues">Propositions de modification</a><a class="button" href="process">Processus de gouvernance</a>
 </div>
 
 <hr/>
 
 ## Versions de cette documentation
 
-- [Version actuelle](reference) - Version 3.0-RC2
-- [v3.0-RC](https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md) - Version 3.0-RC
+- [Version actuelle](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2
 - [v2.1](https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md) - Version 2.1

--- a/docs/fr/specification/reference.md
+++ b/docs/fr/specification/reference.md
@@ -1,2 +1,2 @@
 # General Bikeshare Feed Specification (GBFS)
-{{ external_markdown('https://raw.githubusercontent.com/MobilityData/gbfs/master/gbfs.md', '') }}
+{{ external_markdown('https://raw.githubusercontent.com/MobilityData/gbfs/v3.0/gbfs.md', '') }}


### PR DESCRIPTION
Follows the release of v3.1-RC (https://github.com/MobilityData/gbfs/pull/637 and https://github.com/MobilityData/gbfs/pull/639).

This PR:
- Adds v3.1-RC to the list of versions in https://gbfs.org/specification/
- Points the reference to the latest official versions (v3.0) in https://gbfs.org/specification/reference/

Before | After
-- | --
<img width="887" alt="image" src="https://github.com/MobilityData/gbfs.org/assets/2423604/6c40220e-31c9-44de-8fc1-db16a31e8d2b"> | <img width="892" alt="Screenshot 2024-05-22 at 14 59 53" src="https://github.com/MobilityData/gbfs.org/assets/2423604/eda71adc-48a2-4f1b-94cf-64648c7eae9b">