### PR TITLE
Ignore virtual env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 site/
 generated/
 node_modules
+venv/


### PR DESCRIPTION
## Context
During the redesign of gbfs.org (https://github.com/MobilityData/gbfs.org/pull/113), the instructions to build the site locally were updated to create & enable a Python virtual environment. 

The changes in the virtual environment should not be tracked.

## What's Changed
This PR adds `venv/` to .gitignore to ignore changes to the local virtual environnement.