### PR TITLE
Update tools validators section

### DIFF
--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -103,7 +103,6 @@ There are a multitude of tools and services available to help with the creation,
 
 - [Go Validator](https://github.com/petoc/gbfs): Go implementation of client, server and validator for GBFS
 - [Java Validator](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Java implementation of validator for GBFS. Maintained by Entur.
-- [npm](https://www.npmjs.com/package/@entur/gbfs-validator): Javascript package of the [gbfs-validator](https://github.com/MobilityData/gbfs-validator). Maintained by Entur.
 
 <hr>
 

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -101,6 +101,7 @@ There are a multitude of tools and services available to help with the creation,
 
 ## Validators
 
+- [GBFS Validator](https://gbfs-validator.mobilitydata.org/): The Canonical GBFS Validator is a tool to check the conformity of a GBFS feed against the official specification including past releases and release candidates.
 - [Go Validator](https://github.com/petoc/gbfs): Go implementation of client, server and validator for GBFS
 - [Java Validator](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Java implementation of validator for GBFS. Maintained by Entur.
 

--- a/docs/es/tools.md
+++ b/docs/es/tools.md
@@ -103,7 +103,6 @@ Hay una multitud de herramientas y servicios disponibles para ayudar con la crea
 
 - [Go Validator](https://github.com/petoc/gbfs): Implementación Go de cliente, servidor y validador para GBFS
 - [Java Validator](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Implementación Java del validador para GBFS. Mantenido por Entur.
-- [npm](https://www.npmjs.com/package/@entur/gbfs-validator): Paquete Javascript del [gbfs-validator](https://github.com/MobilityData/ validador gbfs). Mantenido por Entur.
 
 <hr> 
 

--- a/docs/es/tools.md
+++ b/docs/es/tools.md
@@ -101,6 +101,7 @@ Hay una multitud de herramientas y servicios disponibles para ayudar con la crea
 
 ## Validadores
 
+- [Validador GBFS](https://gbfs-validator.mobilitydata.org/): El validador GBFS canónico es una herramienta para verificar la conformidad de un feed GBFS con la especificación oficial, incluidas las versiones anteriores y las versiones candidatas.
 - [Go Validator](https://github.com/petoc/gbfs): Implementación Go de cliente, servidor y validador para GBFS
 - [Java Validator](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Implementación Java del validador para GBFS. Mantenido por Entur.
 

--- a/docs/fr/tools.md
+++ b/docs/fr/tools.md
@@ -30,7 +30,6 @@ Il existe une multitude d'outils et de services disponibles pour aider à la cr�
 
 - [Go Validator](https://github.com/petoc/gbfs): Implémentation Go du client, du serveur et du validateur pour GBFS.
 - [Validateur Java](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Implémentation Java du validateur pour GBFS. Maintenu par Entur.
-- [npm](https://www.npmjs.com/package/@entur/gbfs-validator): Paquet Javascript du validateur [gbfs](https://github.com/MobilityData/gbfs-validator). Maintenu par Entur.
 
 <hr/>
 

--- a/docs/fr/tools.md
+++ b/docs/fr/tools.md
@@ -26,14 +26,6 @@ Il existe une multitude d'outils et de services disponibles pour aider à la cr�
 
 <hr/>
 
-## Validateurs
-
-- [Validateur GBFS](https://gbfs-validator.mobilitydata.org/): Le Canonical GBFS Validator est un outil permettant de vérifier la conformité d'un flux GBFS par rapport à la spécification officielle, y compris les versions antérieures et les versions candidates.
-- [Go Validator](https://github.com/petoc/gbfs): Implémentation Go du client, du serveur et du validateur pour GBFS.
-- [Validateur Java](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Implémentation Java du validateur pour GBFS. Maintenu par Entur.
-
-<hr/>
-
 ## Données
 
 ### Répertoires d'URL GBFS
@@ -103,6 +95,14 @@ Il existe une multitude d'outils et de services disponibles pour aider à la cr�
 - [GBFS/Open Data Viewer](https://share.municipal.systems/oJl_L-B8f): Visualiser la micromobilité et d'autres données ouvertes.
 - [GBFS-Viewer](https://github.com/idoco/gbfs-viewer): [Visualisez les données de micromobilité](https://idoco.github.io/gbfs-viewer/#) dans votre navigateur.
 - [Validation et visualisation du GBFS](https://transport.data.gouv.fr/validation?type=gbfs\&locale=en): Le PAN français a développé une interface web pour visualiser les flux GBFS.
+
+<hr/>
+
+## Validateurs
+
+- [Validateur GBFS](https://gbfs-validator.mobilitydata.org/): Le Canonical GBFS Validator est un outil permettant de vérifier la conformité d'un flux GBFS par rapport à la spécification officielle, y compris les versions antérieures et les versions candidates.
+- [Go Validator](https://github.com/petoc/gbfs): Implémentation Go du client, du serveur et du validateur pour GBFS.
+- [Validateur Java](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Implémentation Java du validateur pour GBFS. Maintenu par Entur.
 
 <hr/>
 

--- a/docs/fr/tools.md
+++ b/docs/fr/tools.md
@@ -28,6 +28,7 @@ Il existe une multitude d'outils et de services disponibles pour aider à la cr�
 
 ## Validateurs
 
+- [Validateur GBFS](https://gbfs-validator.mobilitydata.org/): Le Canonical GBFS Validator est un outil permettant de vérifier la conformité d'un flux GBFS par rapport à la spécification officielle, y compris les versions antérieures et les versions candidates.
 - [Go Validator](https://github.com/petoc/gbfs): Implémentation Go du client, du serveur et du validateur pour GBFS.
 - [Validateur Java](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java): Implémentation Java du validateur pour GBFS. Maintenu par Entur.
 


### PR DESCRIPTION
## Context
@testower notified MobilityData that Entur no longer maintains a JavaScript package of validator for GBFS. 

Please note that Entur still maintains the [Java implementation](https://central.sonatype.com/artifact/org.entur.gbfs/gbfs-validator-java) of validator for GBFS.

## What's Changed
This PR removes Entur's validator JavaScript package from the tools and adds the GBFS validator website to the Validators section:

![image](https://github.com/user-attachments/assets/af4b2c60-6aa0-4454-a18b-74dc3aad611b)