### PR TITLE
Fix/114 language url switch

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -44,6 +44,9 @@ extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/footer.css
 
+extra_javascript:
+  - assets/javascript/languageSwitchUrls.js
+
 extra:
   analytics:
     provider: google

--- a/config/es/mkdocs.yml
+++ b/config/es/mkdocs.yml
@@ -44,6 +44,9 @@ extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/footer.css
 
+extra_javascript:
+  - assets/javascript/languageSwitchUrls.js
+
 extra:
   analytics:
     provider: google

--- a/config/fr/mkdocs.yml
+++ b/config/fr/mkdocs.yml
@@ -44,6 +44,9 @@ extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/footer.css
 
+extra_javascript:
+  - assets/javascript/languageSwitchUrls.js
+
 extra:
   analytics:
     provider: google

--- a/overrides/assets/javascript/languageSwitchUrls.js
+++ b/overrides/assets/javascript/languageSwitchUrls.js
@@ -1,0 +1,38 @@
+console.log("BING JS LOADED lang");
+document.addEventListener("DOMContentLoaded", function () {
+    const currentPath = window.location.pathname;
+    const switcherLinks = document.querySelectorAll(".md-header__option .md-select__item a");
+
+    switcherLinks.forEach(link => {
+        const langCode = link.getAttribute("hreflang") === "en" ? "" : "/" + link.getAttribute("hreflang");
+
+        // Detect the current language from the URL
+        const langPrefixes = ["en", "fr", "es"];
+        const pathParts = currentPath.split("/").filter(Boolean);
+        let currentLang = langPrefixes.includes(pathParts[0]) ? pathParts[0] : "en"; // Default to "en"
+
+        let newPath;
+        if (currentLang !== "en") {
+            newPath = currentPath.replace(`/${currentLang}/`, `${langCode}/`);
+        } else {
+            newPath = `${langCode}${currentPath}`;
+        }
+
+        link.href = newPath;
+        
+        /**
+         * Hack:
+         * When switching languages it forcefully goes to the root languauge page ex: /fr/ or /es/
+         * regardless of the a tag href attribute.
+         * 
+         * Current behavior: es/get-started -> fr/get-started -> /fr/ [bad behavior]
+         * 
+         * With the setTimeout it calls the /fr/ then the correct href
+         * 
+         * After fix: es/get-started -> fr -> fr/get-started [good behavior]
+         */
+        link.addEventListener("click", function () {
+            setTimeout(() => window.location.href = newPath);
+        });
+    });
+});

--- a/overrides/assets/javascript/languageSwitchUrls.js
+++ b/overrides/assets/javascript/languageSwitchUrls.js
@@ -1,4 +1,3 @@
-console.log("BING JS LOADED lang");
 document.addEventListener("DOMContentLoaded", function () {
     const currentPath = window.location.pathname;
     const switcherLinks = document.querySelectorAll(".md-header__option .md-select__item a");


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs.org/issues/114

When on a page (excluding landing) and the user switches languages, it brings them to the landing page of the newly selected language. This is not desired behaviour.

This PR will make it so that the user will stay on the same page, just different language