### PR TITLE
Replace Productboard roadmap with Airtable

### DIFF
--- a/docs/en/community.md
+++ b/docs/en/community.md
@@ -33,11 +33,15 @@ The following items have passed through the voting process and will be included 
 </div>
 
 
-## Get Involved
-This roadmap has been developed based on feedback we have received from the GBFS community and shared mobility industry. If there are features or changes that you think should be part of this roadmap we'd like to hear about them. GBFS is an open project and we value your input.
-If you would like to contribute to the project please use the **Submit idea** button or get in touch with us at [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org) to coordinate contribution.
+## In Discussion
+The following items are in discussion. If there are features or changes that you think should be part of the specification we'd like to hear about them. GBFS is an open project and we value your input.
+If you would like to contribute to the project please open an issue on [GitHub](https://github.com/MobilityData/gbfs/issues) or get in touch with us at [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org) to coordinate contribution.
 
-<iframe src="https://portal.productboard.com/26qpteg4wct9px3jts94uqv8?hide_logo=1" frameborder="0" height=700px width=100%></iframe>
+<iframe class="airtable-embed" src="https://airtable.com/embed/appQvTu1nOy6fJwUP/shrGT3fXS21vl1xMK?viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+<div class="button-holder">
+    <a class="md-button md-button--primary no-icon" href="https://github.com/MobilityData/gbfs/issues" target="_blank">Open an issue on GitHub</a>
+</div>
 
 ## Comments and Questions
 

--- a/docs/es/community.md
+++ b/docs/es/community.md
@@ -33,11 +33,15 @@ Los siguientes elementos han pasado por el proceso de votación y se incluirán 
 </div>
 
 
-## Participe
-Esta hoja de ruta se desarrolló en base a los comentarios que recibimos de la comunidad GBFS y la industria de la movilidad compartida. Si hay características o cambios que cree que deberían ser parte de esta hoja de ruta, nos gustaría conocerlos. GBFS es un proyecto abierto y valoramos sus aportes.
-Si desea contribuir al proyecto, utilice el botón **Enviar idea** o póngase en contacto con nosotros en [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org) para coordinar la contribución.
+## En discusión
+Los siguientes temas están en discusión. Si hay características o cambios que cree que deberían ser parte de esta hoja de ruta, nos gustaría conocerlos. GBFS es un proyecto abierto y valoramos sus aportes.
+Si desea contribuir al proyecto, abra un issue en [GitHub](https://github.com/MobilityData/gbfs/issues) o póngase en contacto con nosotros en [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org) para coordinar la contribución.
 
- <iframe src="https://portal.productboard.com/26qpteg4wct9px3jts94uqv8?hide_logo=1" frameborder="0" height=700px width=100%></iframe> 
+<iframe class="airtable-embed" src="https://airtable.com/embed/appQvTu1nOy6fJwUP/shrGT3fXS21vl1xMK?viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+<div class="button-holder">
+    <a class="md-button md-button--primary no-icon" href="https://github.com/MobilityData/gbfs/issues" target="_blank">Abrir un issue en GitHub</a>
+</div>
 
 ## Comentarios y preguntas
 

--- a/docs/fr/community.md
+++ b/docs/fr/community.md
@@ -16,9 +16,9 @@ Toutes les propositions de modification sont soumises au processus de gouvernanc
 
 Pour soutenir ce processus et s'assurer qu'il est aussi rapide que possible, MobilityData suit la mise en œuvre par le biais de discussions individuelles et d'autres événements avec les parties prenantes, ainsi qu'en examinant les ensembles de données GBFS. Pour améliorer ce processus de suivi, les producteurs et les applications réutilisatrices de données GBFS sont encouragés à ajouter leur organisation ici s'ils ont mis en œuvre ou prévoient de mettre en œuvre l'un de ces changements de la version candidate. Après les votes, MobilityData mettra à jour cette liste pour refléter les organisations qui ont inclus une note de mise en œuvre dans leur vote.
 
-## Premiers adoptant·es
+## Premiers adoptants
 
-🎉 Bravo aux premiers adoptant·es ! Ces organisations investissent beaucoup de temps et d'énergie pour mettre en œuvre les changements contenus dans la version candidate et s'assurer que le GBFS continue d'évoluer.
+🎉 Bravo aux premiers adoptants ! Ces organisations investissent beaucoup de temps et d'énergie pour mettre en œuvre les changements contenus dans la version candidate et s'assurer que le GBFS continue d'évoluer.
 
 - Producteurs : [Check](https://ridecheck.app/en), [ENTUR](https://entur.no/), [Flamingo](https://flamingoscooters.com/), [TIER](https://www.tier.app/).
 - Applications réutilisatrices : [Dashboard Deelmobiliteit](https://dashboarddeelmobiliteit.nl/), [ENTUR](https://entur.no/), [Transit](https://transitapp.com/?lang=fr), [transport.data.gouv.fr](https://transport.data.gouv.fr/), [Where To?](https://www.whereto.app/).
@@ -36,11 +36,15 @@ Les éléments suivants ont été soumis au processus de vote et seront inclus d
 </div>
 
 
-## S'impliquer
+## En discussion
 
-Cette feuille de route a été élaborée sur la base des commentaires que nous avons reçus de la communauté GBFS et de l'industrie de la mobilité partagée. Si vous pensez qu'il y a des fonctionnalités ou des changements qui devraient faire partie de cette feuille de route, nous aimerions les connaître. Si vous souhaitez contribuer au projet, veuillez utiliser le bouton " **Submit idea"** ou nous contacter à l'adresse <sharedmobility@mobilitydata.org> pour coordonner votre contribution.
+Les éléments suivants sont en discussion. Si vous pensez qu'il y a des fonctionnalités ou des changements qui devraient faire partie de la spécification, nous aimerions les connaître. Si vous souhaitez contribuer au projet, veuillez ouvrir une issue sur [GitHub](https://github.com/MobilityData/gbfs/issues) ou nous contacter à l'adresse <sharedmobility@mobilitydata.org> pour coordonner votre contribution.
 
-<iframe src="https://portal.productboard.com/26qpteg4wct9px3jts94uqv8?hide_logo=1" frameborder="0" height=700px width=100%></iframe>
+<iframe class="airtable-embed" src="https://airtable.com/embed/appQvTu1nOy6fJwUP/shrGT3fXS21vl1xMK?viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+<div class="button-holder">
+    <a class="md-button md-button--primary no-icon" href="https://github.com/MobilityData/gbfs/issues" target="_blank">Ouvrir une issue sur GitHub</a>
+</div>
 
 ## Commentaires et questions
 


### PR DESCRIPTION
## Context
Migrating the public roadmap from Productboard to Airtable for consistency with the Implementation Status on https://gbfs.org/community/.

## What's Changed
- Replaced Productboard roadmap with [Airtable](https://airtable.com/appQvTu1nOy6fJwUP/tbltQn9TWPrgmSYQD/viw7GyfAxWWtfB7W9?blocks=hide).
- Removed items that are already in the Implementation Status table and added new issues from [GitHub](https://github.com/MobilityData/gbfs/issues).

Before | After
-- | --
<img width="1798" alt="image" src="https://github.com/user-attachments/assets/68b40893-1f2a-4c43-95e2-4192ec67ac71" /> | <img width="1796" alt="image" src="https://github.com/user-attachments/assets/4a66ac46-9ab6-44e2-87ed-9346cb0c21d2" />