### PR TITLE
Update Pre-release version to v3.1-RC2

### DIFF
--- a/docs/en/documentation/index.md
+++ b/docs/en/documentation/index.md
@@ -6,7 +6,7 @@
 
 ## Versions of this documentation
 
-- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC/gbfs.md) - Version 3.1-RC
+- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md) - Version 3.1-RC2
 - [Latest](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2

--- a/docs/es/documentation/index.md
+++ b/docs/es/documentation/index.md
@@ -6,7 +6,7 @@
 
 ## Versiones de esta documentación
 
-- [Prelanzamiento](https://github.com/MobilityData/gbfs/blob/v3.1-RC/gbfs.md) - Versión 3.1-RC
+- [Prelanzamiento](https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md) - Versión 3.1-RC2
 - [Última](referencia) - Versión 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Versión 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Versión 2.2

--- a/docs/fr/documentation/index.md
+++ b/docs/fr/documentation/index.md
@@ -6,7 +6,7 @@
 
 ## Versions de cette documentation
 
-- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC/gbfs.md) - Version 3.1-RC
+- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md) - Version 3.1-RC2
 - [Version actuelle](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2


### PR DESCRIPTION
## Context

v3.1-RC2 will be released in https://github.com/MobilityData/gbfs/pull/761. The gbfs.org website needs to list this new Pre-release version.

## What's Changed

This PR bumps the Pre-release version to v3.1-RC2 on https://gbfs.org/documentation/.

Before | After
-- | --
![image](https://github.com/user-attachments/assets/6431f1e9-2f9e-462c-95b0-d245a143f17d) | ![image](https://github.com/user-attachments/assets/2d995e1b-a0c4-4c6c-9e10-8e4e9da151f3)

## Additional Notes
It is expected that the URL https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md does not work yet. It will work when https://github.com/MobilityData/gbfs/pull/761 will be merged.