### PR TITLE
Add Golang to the list of GBFS language bindings

### DIFF
--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -17,6 +17,7 @@ There are a multitude of tools and services available to help with the creation,
 - [TypeScript](https://www.npmjs.com/package/gbfs-typescript-types): GBFS types in TypeScript. Hosted by MobilityData.
 - [Rust](https://crates.io/crates/gbfs_types): GBFS types in Rust. Maintained by Fluctuo.
 - [R](https://github.com/simonpcouch/gbfs): GBFS types in R. 
+- [Golang](https://pkg.go.dev/github.com/MobilityData/gbfs-json-schema/models/golang): GBFS types in Golang. 
 
 ### Tools
 

--- a/docs/es/tools.md
+++ b/docs/es/tools.md
@@ -17,6 +17,7 @@ Hay una multitud de herramientas y servicios disponibles para ayudar con la crea
 - [TypeScript](https://www.npmjs.com/package/gbfs-typescript-types): tipos GBFS en TypeScript. Organizado por MobilityData.
 - [Rust](https://crates.io/crates/gbfs_types): tipos de GBFS en Rust. Mantenido por Fluctuo.
 - [R](https://github.com/simonpcouch/gbfs): Tipos de GBFS en R. 
+- [Golang](https://pkg.go.dev/github.com/MobilityData/gbfs-json-schema/models/golang): Tipos de GBFS en Golang. 
 
 ### Herramientas
 

--- a/docs/fr/tools.md
+++ b/docs/fr/tools.md
@@ -17,6 +17,7 @@ Il existe une multitude d'outils et de services disponibles pour aider à la cr�
 - [TypeScript](https://www.npmjs.com/package/gbfs-typescript-types): Types GBFS en TypeScript. Hébergé par MobilityData.
 - [Rust](https://crates.io/crates/gbfs_types): Modèle de données GBFS en Rust. Maintenu par Fluctuo.
 - [R](https://github.com/simonpcouch/gbfs): Modèle de données GBFS en R.
+- [Golang](https://pkg.go.dev/github.com/MobilityData/gbfs-json-schema/models/golang): Modèle de données GBFS en Golang. 
 
 ### Les outils
 


### PR DESCRIPTION
## Context
The GBFS model in Golang was updated to GBFS v3.1-RC2 in https://github.com/MobilityData/gbfs-json-schema/pull/173.

## What's Changed
This PR adds Golang to the list of GBFS language bindings in the tools section on gbfs.org: https://gbfs.org/tools/#language-bindings-for-gbfs