### PR TITLE
Update pre-release version to v3.1-RC3

### DIFF
--- a/docs/en/documentation/index.md
+++ b/docs/en/documentation/index.md
@@ -6,7 +6,7 @@
 
 ## Versions of this documentation
 
-- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md) - Version 3.1-RC2
+- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC3/gbfs.md) - Version 3.1-RC3
 - [Latest](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2

--- a/docs/es/documentation/index.md
+++ b/docs/es/documentation/index.md
@@ -6,7 +6,7 @@
 
 ## Versiones de esta documentación
 
-- [Prelanzamiento](https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md) - Versión 3.1-RC2
+- [Prelanzamiento](https://github.com/MobilityData/gbfs/blob/v3.1-RC3/gbfs.md) - Versión 3.1-RC3
 - [Última](referencia) - Versión 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Versión 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Versión 2.2

--- a/docs/fr/documentation/index.md
+++ b/docs/fr/documentation/index.md
@@ -6,7 +6,7 @@
 
 ## Versions de cette documentation
 
-- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC2/gbfs.md) - Version 3.1-RC2
+- [Pre-release](https://github.com/MobilityData/gbfs/blob/v3.1-RC3/gbfs.md) - Version 3.1-RC3
 - [Version actuelle](reference) - Version 3.0
 - [v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md) - Version 2.3
 - [v2.2](https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md) - Version 2.2


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs.org/issues/140

This PR updates the pre-release version to v3.1-RC3 on gbfs.org.